### PR TITLE
Bug fix in Chapter 5 Sample Code method clearBitsIthrough0

### DIFF
--- a/java/Chapter 5/Sample_Code/Sample_Code.java
+++ b/java/Chapter 5/Sample_Code/Sample_Code.java
@@ -28,7 +28,7 @@ public class Sample_Code {
 	}
 	
 	public static int clearBitsIthrough0(int num, int i) {
-		int mask = ~((1 << (i+1)) - 1);
+		int mask = ~(-1 >>> (31 - i));
 		return num & mask;
 	}
 	


### PR DESCRIPTION
The previous version doesn't work when i = 31 because the innermost part of the mask will be (1 << 32), which evaluates to 1 in Java. So the mask will end up being ~0, which will not clear any of the bits.
