### PR TITLE
Javascript: Adjusting global names of LinkedList solutions so that all the tests can pass

### DIFF
--- a/javascript/lib/data-structures/chapter-2/2_1.js
+++ b/javascript/lib/data-structures/chapter-2/2_1.js
@@ -1,4 +1,4 @@
-module.exports = LinkedList = (function() {
+module.exports = LinkedList_2_1 = (function() {
   var deleteDuplicatesA = function(linkedList) {
     if(!linkedList || !linkedList.head) return;
     var values = {};

--- a/javascript/lib/data-structures/chapter-2/2_2.js
+++ b/javascript/lib/data-structures/chapter-2/2_2.js
@@ -1,4 +1,4 @@
-module.exports = LinkedList = (function() {
+module.exports = LinkedList_2_2 = (function() {
   /* 
    * Return the kth element from the end
    * Make a stack of pointers to each linked list element

--- a/javascript/lib/data-structures/chapter-2/2_3.js
+++ b/javascript/lib/data-structures/chapter-2/2_3.js
@@ -1,4 +1,4 @@
-module.exports = LinkedList = (function() {
+module.exports = LinkedList_2_3 = (function() {
   var deleteNode = function(node) {
     if(!node || !node.next) return;
     var next = node.next;

--- a/javascript/test/data-structures/chapter-2/2_1_Spec.js
+++ b/javascript/test/data-structures/chapter-2/2_1_Spec.js
@@ -1,10 +1,10 @@
 require('../../test_helper');
-describe(LinkedList, function () {
-  describe('LinkedList deleteDuplicatesA', function () {
+describe(LinkedList_2_1, function () {
+  describe('LinkedList_2_1 deleteDuplicatesA', function () {
 
   it('returns 0 length list if 0 length list', function () {
       var l = new SinglyLinkedList();
-      LinkedList.deleteDuplicatesA(l);
+      LinkedList_2_1.deleteDuplicatesA(l);
 
       expect(l.head).to.be.undefined;
     });
@@ -12,7 +12,7 @@ describe(LinkedList, function () {
     it('returns 1 length list if 1 length list', function () {
       var l = new SinglyLinkedList();
       l.addBottom(new Node("foo"));
-      LinkedList.deleteDuplicatesA(l);
+      LinkedList_2_1.deleteDuplicatesA(l);
 
       expect(l.head).to.be.not.null;
       expect(l.head.next).to.be.undefined;
@@ -22,7 +22,7 @@ describe(LinkedList, function () {
       var l = new SinglyLinkedList();
       l.addBottom(new Node("foo"));
       l.addBottom(new Node("foo"));
-      LinkedList.deleteDuplicatesA(l);
+      LinkedList_2_1.deleteDuplicatesA(l);
 
       expect(l.head).to.be.not.null;
       expect(l.head.next).to.be.undefined;
@@ -33,7 +33,7 @@ describe(LinkedList, function () {
       l.addBottom(new Node("foo"));
       l.addBottom(new Node("foo"));
       l.addBottom(new Node("bar"));
-      LinkedList.deleteDuplicatesA(l);
+      LinkedList_2_1.deleteDuplicatesA(l);
 
       expect(l.head).to.be.not.null;
       expect(l.head.next).to.be.not.null;
@@ -41,11 +41,11 @@ describe(LinkedList, function () {
     });
     
   });
-describe('LinkedList deleteDuplicatesB', function () {
+describe('LinkedList_2_1 deleteDuplicatesB', function () {
 
   it('returns 0 length list if 0 length list', function () {
       var l = new SinglyLinkedList();
-      LinkedList.deleteDuplicatesB(l);
+      LinkedList_2_1.deleteDuplicatesB(l);
 
       expect(l.head).to.be.undefined;
     });
@@ -53,7 +53,7 @@ describe('LinkedList deleteDuplicatesB', function () {
     it('returns 1 length list if 1 length list', function () {
       var l = new SinglyLinkedList();
       l.addBottom(new Node("foo"));
-      LinkedList.deleteDuplicatesB(l);
+      LinkedList_2_1.deleteDuplicatesB(l);
 
       expect(l.head).to.be.not.null;
       expect(l.head.next).to.be.undefined;
@@ -63,7 +63,7 @@ describe('LinkedList deleteDuplicatesB', function () {
       var l = new SinglyLinkedList();
       l.addBottom(new Node("foo"));
       l.addBottom(new Node("foo"));
-      LinkedList.deleteDuplicatesB(l);
+      LinkedList_2_1.deleteDuplicatesB(l);
 
       expect(l.head).to.be.not.null;
       expect(l.head.next).to.be.undefined;
@@ -74,7 +74,7 @@ describe('LinkedList deleteDuplicatesB', function () {
       l.addBottom(new Node("foo"));
       l.addBottom(new Node("foo"));
       l.addBottom(new Node("bar"));
-      LinkedList.deleteDuplicatesB(l);
+      LinkedList_2_1.deleteDuplicatesB(l);
 
       expect(l.head).to.be.not.null;
       expect(l.head.next).to.be.not.null;

--- a/javascript/test/data-structures/chapter-2/2_2_Spec.js
+++ b/javascript/test/data-structures/chapter-2/2_2_Spec.js
@@ -1,24 +1,24 @@
 require('../../test_helper');
-describe(LinkedList, function () {
-  describe('LinkedList findKthElementFromEnd #2C (recursion returning array of node and counter)', function () {
+describe(LinkedList_2_2, function () {
+  describe('LinkedList_2_2 findKthElementFromEnd #2C (recursion returning array of node and counter)', function () {
 
   it('returns null if 0 length list', function () {
       var l = new SinglyLinkedList();
-      var item = LinkedList.findKthElementFromEnd2C(l, 1);
+      var item = LinkedList_2_2.findKthElementFromEnd2C(l, 1);
       expect(item).to.be.null;
     });
     
     it('returns null if k >= list length', function () {
       var l = new SinglyLinkedList();
       l.addBottom(new Node("foo"));
-      var item = LinkedList.findKthElementFromEnd2C(l, 1);
+      var item = LinkedList_2_2.findKthElementFromEnd2C(l, 1);
       expect(item).to.be.null;
     });
 
     it('returns 1st item in 1 length list k == 0', function () {
       var l = new SinglyLinkedList();
       l.addBottom(new Node("foo"));
-      var item = LinkedList.findKthElementFromEnd2C(l, 0);
+      var item = LinkedList_2_2.findKthElementFromEnd2C(l, 0);
       expect(item).to.be.not.null;
       expect(item.data).to.equal("foo");
     });
@@ -28,7 +28,7 @@ describe(LinkedList, function () {
       var l = new SinglyLinkedList();
       l.addBottom(new Node("foo"));
       l.addBottom(new Node("bar"));
-      var item = LinkedList.findKthElementFromEnd2C(l, 0);
+      var item = LinkedList_2_2.findKthElementFromEnd2C(l, 0);
       expect(item).to.be.not.null;
       expect(item.data).to.equal("bar");
     });
@@ -37,32 +37,32 @@ describe(LinkedList, function () {
       var l = new SinglyLinkedList();
       l.addBottom(new Node("foo"));
       l.addBottom(new Node("bar"));
-      var item = LinkedList.findKthElementFromEnd2C(l, 1);
+      var item = LinkedList_2_2.findKthElementFromEnd2C(l, 1);
       expect(item).to.be.not.null;
       expect(item.data).to.equal("foo");
     });
     
   });
 
-describe('LinkedList findKthElementFromEnd #4 (stack of pointers to linked list items)', function () {
+describe('LinkedList_2_2 findKthElementFromEnd #4 (stack of pointers to linked list items)', function () {
 
   it('returns null if 0 length list', function () {
       var l = new SinglyLinkedList();
-      var item = LinkedList.findKthElementFromEnd4(l, 1);
+      var item = LinkedList_2_2.findKthElementFromEnd4(l, 1);
       expect(item).to.be.null;
     });
     
     it('returns null if k >= list length', function () {
       var l = new SinglyLinkedList();
       l.addBottom(new Node("foo"));
-      var item = LinkedList.findKthElementFromEnd4(l, 1);
+      var item = LinkedList_2_2.findKthElementFromEnd4(l, 1);
       expect(item).to.be.null;
     });
 
     it('returns 1st item in 1 length list k == 0', function () {
       var l = new SinglyLinkedList();
       l.addBottom(new Node("foo"));
-      var item = LinkedList.findKthElementFromEnd4(l, 0);
+      var item = LinkedList_2_2.findKthElementFromEnd4(l, 0);
       expect(item).to.be.not.null;
       expect(item.data).to.equal("foo");
     });
@@ -72,7 +72,7 @@ describe('LinkedList findKthElementFromEnd #4 (stack of pointers to linked list 
       var l = new SinglyLinkedList();
       l.addBottom(new Node("foo"));
       l.addBottom(new Node("bar"));
-      var item = LinkedList.findKthElementFromEnd4(l, 0);
+      var item = LinkedList_2_2.findKthElementFromEnd4(l, 0);
       expect(item).to.be.not.null;
       expect(item.data).to.equal("bar");
     });
@@ -81,7 +81,7 @@ describe('LinkedList findKthElementFromEnd #4 (stack of pointers to linked list 
       var l = new SinglyLinkedList();
       l.addBottom(new Node("foo"));
       l.addBottom(new Node("bar"));
-      var item = LinkedList.findKthElementFromEnd4(l, 1);
+      var item = LinkedList_2_2.findKthElementFromEnd4(l, 1);
       expect(item).to.be.not.null;
       expect(item.data).to.equal("foo");
     });

--- a/javascript/test/data-structures/chapter-2/2_3_Spec.js
+++ b/javascript/test/data-structures/chapter-2/2_3_Spec.js
@@ -1,10 +1,10 @@
 require('../../test_helper');
-describe(LinkedList, function () {
+describe(LinkedList_2_3, function () {
   describe('deleteNode)', function () {
 
   it('runs if 0 length list', function () {
       var l = new SinglyLinkedList();
-      LinkedList.deleteNode(l, new Node("foo"));
+      LinkedList_2_3.deleteNode(l, new Node("foo"));
       expect(l).to.be.not.null;
     });
     
@@ -14,7 +14,7 @@ describe(LinkedList, function () {
       var n = new Node("foo");
       l.addBottom(n);
       l.addBottom(new Node("bar"));
-      LinkedList.deleteNode(n);
+      LinkedList_2_3.deleteNode(n);
       expect(l.head).to.equal(n);
       expect(l.head.data).to.equal("bar");
     });
@@ -28,7 +28,7 @@ describe(LinkedList, function () {
       l.addBottom(new Node("d"));
       l.addBottom(new Node("e"));
       
-      LinkedList.deleteNode(n);
+      LinkedList_2_3.deleteNode(n);
       expect(l.head).to.be.not.null;
       expect(l.head.data).to.equal("a");
       expect(l.head.next.data).to.equal("b");


### PR DESCRIPTION
Out of the box, in order to get `$ mocha --recursive` to pass, I needed to change the names of the globals used

```
  $ mocha --recursive

  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  55 passing (13ms)

```

Adjusting global names of LinkedList solutions so that all the tests can be run and passed otherwise 2_2 clobbers 2_1 and 2_3 clobbers 2_2

Without these changes I got 18 failing tests:

```
$ mocha --recursive --debug-brk
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  37 passing (2m)
  18 failing

  1) [object Object] LinkedList deleteDuplicatesA returns 0 length list if 0 length list:
     TypeError: Object #<Object> has no method 'deleteDuplicatesA'
      at Context.<anonymous> (/work/labs/ctci/javascript/test/data-structures/chapter-2/2_1_Spec.js:7:18)
      at callFn (/usr/local/lib/node_modules/mocha/lib/runnable.js:223:21)
      at Test.Runnable.run (/usr/local/lib/node_modules/mocha/lib/runnable.js:2
```
