### PR TITLE
Improve efficiency of convertToBase method

### DIFF
--- a/java/Introduction/CompareBinaryToHex/CompareBinaryToHex.java
+++ b/java/Introduction/CompareBinaryToHex/CompareBinaryToHex.java
@@ -16,13 +16,12 @@ public class CompareBinaryToHex {
 	public static int convertToBase(String number, int base) {
 		if (base < 2 || (base > 10 && base != 16)) return -1;
 		int value = 0;
-		for (int i = number.length() - 1; i >= 0; i--) {
+		for (int i = 0, n = number.length(); i < n; i++) {
 			int digit = digitToValue(number.charAt(i));
 			if (digit < 0 || digit >= base) {
 				return -1;
 			}
-			int exp = number.length() - 1 - i;
-			value += digit * Math.pow(base, exp);
+			value = value * base + digit;
 		}
 		return value;
 	}


### PR DESCRIPTION
* Instead of calling Math.pow at each iteration, use Horner's rule to
  compute the value of the polynomial.

* Instead of invoking length() at each iteration, assign the length of
  the String to a variable in the initialization part of the for loop.